### PR TITLE
Add Access Point (AP) and concurrent AP+STA mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,22 @@ Available commands:
 ```text
 set ssid MyWiFiNetwork
 set password MySecretPassword
+set ap_ssid LeafLocalAP
+set ap_password LeafLocalPassword
 set mqtt_server 192.168.1.100
 reboot
 ```
 
 *Supported Configuration Keys:*
-* `ssid`, `password`, `hostName`
+* `ssid`, `password` (For connecting to an existing Wi-Fi network / STA mode)
+* `ap_ssid`, `ap_password` (For creating a local Wi-Fi Access Point / AP mode)
+* `hostName`
 * `mqtt_server`, `mqtt_port`, `mqtt_user`, `mqtt_password`, `vehicle_id`
+
+**Wi-Fi Modes:**
+* **STA Mode:** Active when `ssid` is configured. The device connects to your home/garage Wi-Fi.
+* **AP Mode:** Active when `ap_ssid` is configured. The device broadcasts its own Wi-Fi network (useful when away from home).
+* **AP + STA Mode:** Active when both `ssid` and `ap_ssid` are configured. The device will connect to your home Wi-Fi while simultaneously broadcasting its own Access Point.
 
 ## Compiling and Uploading with Arduino IDE
 

--- a/simppeliTCU/cliParser.cpp
+++ b/simppeliTCU/cliParser.cpp
@@ -16,6 +16,8 @@ void executeCommand(char* cmd) {
         Serial.println("Current Configuration:");
         Serial.printf("  ssid: %s\n", getWifiSSID());
         Serial.printf("  password: %s\n", showSecrets ? getWifiPassword() : "****");
+        Serial.printf("  ap_ssid: %s\n", getApSSID());
+        Serial.printf("  ap_password: %s\n", showSecrets ? getApPassword() : "****");
         Serial.printf("  hostName: %s\n", getHostName());
         Serial.printf("  mqtt_server: %s\n", getMqttServer());
         Serial.printf("  mqtt_port: %d\n", getMqttPort());
@@ -31,6 +33,8 @@ void executeCommand(char* cmd) {
         if (key != NULL) {
             if (strcmp(key, "ssid") == 0) Serial.println(getWifiSSID());
             else if (strcmp(key, "password") == 0) Serial.println("****");
+            else if (strcmp(key, "ap_ssid") == 0) Serial.println(getApSSID());
+            else if (strcmp(key, "ap_password") == 0) Serial.println("****");
             else if (strcmp(key, "hostName") == 0) Serial.println(getHostName());
             else if (strcmp(key, "mqtt_server") == 0) Serial.println(getMqttServer());
             else if (strcmp(key, "mqtt_port") == 0) Serial.println(getMqttPort());
@@ -52,6 +56,8 @@ void executeCommand(char* cmd) {
 
             if (strcmp(key, "ssid") == 0) status = setWifiSSID(val);
             else if (strcmp(key, "password") == 0) status = setWifiPassword(val);
+            else if (strcmp(key, "ap_ssid") == 0) status = setApSSID(val);
+            else if (strcmp(key, "ap_password") == 0) status = setApPassword(val);
             else if (strcmp(key, "hostName") == 0) status = setHostName(val);
             else if (strcmp(key, "mqtt_server") == 0) status = setMqttServer(val);
             else if (strcmp(key, "mqtt_port") == 0) {

--- a/simppeliTCU/configuration.cpp
+++ b/simppeliTCU/configuration.cpp
@@ -68,6 +68,8 @@ public:
 // Define config objects
 static ConfigString<64> conf_ssid("ssid", "");
 static ConfigString<64> conf_password("password", "");
+static ConfigString<64> conf_ap_ssid("ap_ssid", "");
+static ConfigString<64> conf_ap_password("ap_password", "");
 static ConfigString<64> conf_hostName("hostName", "leaf");
 static ConfigString<64> conf_mqtt_server("mqtt_server", "");
 static ConfigInt        conf_mqtt_port("mqtt_port", 8883);
@@ -83,6 +85,8 @@ void initConfiguration() {
 
     conf_ssid.load();
     conf_password.load();
+    conf_ap_ssid.load();
+    conf_ap_password.load();
     conf_hostName.load();
     conf_mqtt_server.load();
     conf_mqtt_port.load();
@@ -96,6 +100,12 @@ ConfigStatus setWifiSSID(const char* value) { return conf_ssid.set(value); }
 
 const char* getWifiPassword() { return conf_password.get(); }
 ConfigStatus setWifiPassword(const char* value) { return conf_password.set(value); }
+
+const char* getApSSID() { return conf_ap_ssid.get(); }
+ConfigStatus setApSSID(const char* value) { return conf_ap_ssid.set(value); }
+
+const char* getApPassword() { return conf_ap_password.get(); }
+ConfigStatus setApPassword(const char* value) { return conf_ap_password.set(value); }
 
 const char* getHostName() { return conf_hostName.get(); }
 ConfigStatus setHostName(const char* value) {

--- a/simppeliTCU/configuration.h
+++ b/simppeliTCU/configuration.h
@@ -21,6 +21,12 @@ ConfigStatus setWifiSSID(const char* value);
 const char* getWifiPassword();
 ConfigStatus setWifiPassword(const char* value);
 
+const char* getApSSID();
+ConfigStatus setApSSID(const char* value);
+
+const char* getApPassword();
+ConfigStatus setApPassword(const char* value);
+
 const char* getHostName();
 ConfigStatus setHostName(const char* value);
 

--- a/simppeliTCU/simppeliTCU.ino
+++ b/simppeliTCU/simppeliTCU.ino
@@ -154,6 +154,13 @@ void handleMqttChargeOn() {
 
 void manageWiFi() {
   if(!wifiEnabled) return;
+  bool staEnabled = strlen(getWifiSSID()) > 0;
+
+  if (!staEnabled) {
+    // AP-only mode, no need to manage STA connection
+    return;
+  }
+
   static unsigned long previousAttemptTime = 0;
   static bool wifiAvailable = false;
   const unsigned long retryInterval = 10000;
@@ -203,9 +210,22 @@ void manageWiFi() {
 void setup() {
   Serial.begin(115200);
   initConfiguration();
+
+  bool staEnabled = strlen(getWifiSSID()) > 0;
+  bool apEnabled = strlen(getApSSID()) > 0;
   
-  if (strlen(getWifiSSID()) > 0) {
+  if (staEnabled && apEnabled) {
+      WiFi.mode(WIFI_AP_STA);
+      WiFi.softAP(getApSSID(), getApPassword());
       WiFi.begin(getWifiSSID(), getWifiPassword());
+      wifiEnabled = true;
+  } else if (staEnabled) {
+      WiFi.mode(WIFI_STA);
+      WiFi.begin(getWifiSSID(), getWifiPassword());
+      wifiEnabled = true;
+  } else if (apEnabled) {
+      WiFi.mode(WIFI_AP);
+      WiFi.softAP(getApSSID(), getApPassword());
       wifiEnabled = true;
   }
   else {


### PR DESCRIPTION
Introduces the ability for the device to operate as a local Wi-Fi Access Point, allowing users to connect to and control it even when away from their home network.