### PR TITLE
Add factory-reset CLI command

### DIFF
--- a/simppeliTCU/cliParser.cpp
+++ b/simppeliTCU/cliParser.cpp
@@ -100,6 +100,12 @@ void executeCommand(char* cmd) {
         delay(100);
         ESP.restart();
     } 
+    else if (strcmp(command, "factory-reset") == 0) {
+        Serial.println("Performing factory reset...");
+        factoryReset();
+        delay(100);
+        ESP.restart();
+    }
     else {
         Serial.println("Unknown command.");
     }

--- a/simppeliTCU/configuration.cpp
+++ b/simppeliTCU/configuration.cpp
@@ -95,6 +95,12 @@ void initConfiguration() {
     conf_vehicle_id.load();
 }
 
+void factoryReset() {
+    if (nvsReady) {
+        preferences.clear();
+    }
+}
+
 const char* getWifiSSID() { return conf_ssid.get(); }
 ConfigStatus setWifiSSID(const char* value) { return conf_ssid.set(value); }
 

--- a/simppeliTCU/configuration.cpp
+++ b/simppeliTCU/configuration.cpp
@@ -96,8 +96,15 @@ void initConfiguration() {
 }
 
 void factoryReset() {
-    if (nvsReady) {
-        preferences.clear();
+    if (!nvsReady) {
+        Serial.println("Error: Factory reset failed because NVS is not initialized.");
+        return;
+    }
+
+    if (preferences.clear()) {
+        Serial.println("Factory reset completed successfully.");
+    } else {
+        Serial.println("Error: Factory reset failed while clearing NVS.");
     }
 }
 

--- a/simppeliTCU/configuration.h
+++ b/simppeliTCU/configuration.h
@@ -14,6 +14,7 @@ enum class ConfigStatus {
 };
 
 void initConfiguration();
+void factoryReset();
 
 const char* getWifiSSID();
 ConfigStatus setWifiSSID(const char* value);


### PR DESCRIPTION
Added a new `factory-reset` CLI command that completely clears all configured parameters from non-volatile storage (NVS) and automatically reboots the device to restore its default state.