### PR TITLE
Adjust SOC and cabin temperature scaling

### DIFF
--- a/simppeliTCU/canLeaf.cpp
+++ b/simppeliTCU/canLeaf.cpp
@@ -1,4 +1,5 @@
-#include "canLeafZE1.h"
+#include "canLeaf.h"
+#include "canLeafAZE0.h"
 #include <cstring>
 
 // Message parser dispatch
@@ -11,11 +12,29 @@ struct MessageParser {
 // Helper macro to create parser entries from CANMessage objects
 #define CAN_PARSER(msg, handler) { (msg).identifier, decltype(msg)::data_size, handler }
 
+static bool is_ze1 = true; // Default to ZE1 since it is the officially supported model
+
+// Vehicle detection state reset (for testing)
+void resetVehicleDetection() {
+    is_ze1 = true;
+}
+
 // Message-specific handlers
-void handleSOCMessage(const uint8_t* data, uint8_t len) {
+void handleZE1SOCMessage(const uint8_t* data, uint8_t len) {
     (void)len;
+    is_ze1 = true; // Confirmed ZE1
     float soc = extractScaledValue(data, soc_field, soc_scaling);
-    handleRawSOC(soc);
+    handleDashboardSOC(soc);
+}
+
+void handleAZE0SOCMessage(const uint8_t* data, uint8_t len) {
+    (void)len;
+    uint64_t raw = extractBits(data, aze0_soc_field);
+    if (raw != aze0_dashboard_soc_sentinel) {
+        is_ze1 = false; // Confirmed AZE0!
+        float soc = extractScaledValue(data, aze0_soc_field, aze0_soc_scaling);
+        handleDashboardSOC(soc);
+    }
 }
 
 void handleTempMessage(const uint8_t* data, uint8_t len) {
@@ -111,7 +130,8 @@ void handleDoorsAndLocksMessage(const uint8_t* data, uint8_t len) {
 
 // Message parser dispatch table
 static const MessageParser parsers[] = {
-    CAN_PARSER(raw_soc_readout, handleSOCMessage),
+    CAN_PARSER(ze1_dashboard_soc_readout, handleZE1SOCMessage),
+    CAN_PARSER(aze0_dashboard_soc_readout, handleAZE0SOCMessage),
     CAN_PARSER(cabin_temp_readout, handleTempMessage),
     CAN_PARSER(car_awake_readout, handleCarAwakeMessage),
     CAN_PARSER(charger_status_readout, handleChargerMessage),

--- a/simppeliTCU/canLeaf.cpp
+++ b/simppeliTCU/canLeaf.cpp
@@ -38,7 +38,14 @@ void handleAZE0SOCMessage(const uint8_t* data, uint8_t len) {
 }
 
 void handleTempMessage(const uint8_t* data, uint8_t len) {
-    float temp = extractScaledValue(data, cabin_temp_field, cabin_temp_scaling);
+    float temp;
+    if (is_ze1) {
+        if (data[0] == ze1_cabin_temp_sentinel) return;
+        temp = extractScaledValue(data, cabin_temp_field, ze1_cabin_temp_scaling);
+    } else {
+        if (data[0] == aze0_cabin_temp_sentinel) return;
+        temp = extractScaledValue(data, cabin_temp_field, aze0_cabin_temp_scaling);
+    }
     handleCabinTemp(temp);
 }
 

--- a/simppeliTCU/canLeaf.h
+++ b/simppeliTCU/canLeaf.h
@@ -1,11 +1,11 @@
-#ifndef CAN_LEAF_ZE1_H
-#define CAN_LEAF_ZE1_H
+#ifndef CAN_LEAF_H
+#define CAN_LEAF_H
 
 #include "canInterface.h"
 #include "vehicleTypes.h"
 
 // Leaf readout messages
-inline constexpr CANMessage<2> raw_soc_readout = {0x55B};
+inline constexpr CANMessage<8> ze1_dashboard_soc_readout = {0x59E}; // ZE1 dashboard SOC
 inline constexpr CANMessage<1> cabin_temp_readout = {0x54F};
 inline constexpr CANMessage<0> car_awake_readout = {0x601};
 inline constexpr CANMessage<6> charger_status_readout = {0x390};
@@ -26,7 +26,7 @@ inline constexpr CANMessage<4> unlock_doors_data = {0x56E, {0x11, 0x00, 0x00, 0x
 inline constexpr CANMessage<4> lock_doors_data   = {0x56E, {0x60, 0x80, 0x00, 0x00}}; // Lock doors
 
 // ===== CAN Field Definitions (bit 0 = MSB of byte 0) =====
-inline constexpr CANField soc_field = { 0, 10 };    
+inline constexpr CANField soc_field = { 56, 8 };    
 inline constexpr CANField cabin_temp_field = { 0, 8 }; 
 inline constexpr CANField cStatus_field   = { 41, 6 }; 
 inline constexpr CANField qc_state_field  = { 33, 1 }; 
@@ -46,6 +46,7 @@ inline constexpr CANField door_fl_field    = { 4, 1 };
 inline constexpr CANField locked_field     = { 19, 1 };
 
 // Scaling definitions
+inline constexpr FieldScaling soc_scaling        = {false, 0.5f,   0.0f};
 inline constexpr FieldScaling soc_scaling        = {false, 0.1f,   0.0f};
 inline constexpr FieldScaling cabin_temp_scaling = {false, 0.5f,  -40.0f};
 inline constexpr FieldScaling voltage_scaling    = {false, 110.0f, 0.0f};
@@ -53,7 +54,7 @@ inline constexpr FieldScaling setpoint_scaling   = {false, 0.5f,   0.0f};
 inline constexpr FieldScaling fan_speed_scaling  = {false, 100.0f/7, 0.0f};
 
 // Readout callbacks (to be called when a message is received, implemented at application side):
-void handleRawSOC(float soc);
+void handleDashboardSOC(float soc);
 void handleCabinTemp(float temp);
 void handleCarAwake();
 void handleChargerStatus(bool isCharging, ChargerState state);
@@ -89,5 +90,8 @@ void setHVACTargetTemperature(float setpoint);
 
 void startSequence(CanSequence seq, unsigned long currentTimeMs);
 CanSeqResult manageCANSequence(unsigned long currentTimeMs);
+
+// Vehicle detection state reset (for testing)
+void resetVehicleDetection();
 
 #endif

--- a/simppeliTCU/canLeaf.h
+++ b/simppeliTCU/canLeaf.h
@@ -47,8 +47,8 @@ inline constexpr CANField locked_field     = { 19, 1 };
 
 // Scaling definitions
 inline constexpr FieldScaling soc_scaling        = {false, 0.5f,   0.0f};
-inline constexpr FieldScaling soc_scaling        = {false, 0.1f,   0.0f};
-inline constexpr FieldScaling cabin_temp_scaling = {false, 0.5f,  -40.0f};
+inline constexpr FieldScaling ze1_cabin_temp_scaling = {false, 0.5f,  -40.0f};
+inline constexpr uint8_t ze1_cabin_temp_sentinel = 0x50; // 80
 inline constexpr FieldScaling voltage_scaling    = {false, 110.0f, 0.0f};
 inline constexpr FieldScaling setpoint_scaling   = {false, 0.5f,   0.0f};
 inline constexpr FieldScaling fan_speed_scaling  = {false, 100.0f/7, 0.0f};

--- a/simppeliTCU/canLeafAZE0.h
+++ b/simppeliTCU/canLeafAZE0.h
@@ -1,0 +1,17 @@
+#ifndef CAN_LEAF_AZE0_H
+#define CAN_LEAF_AZE0_H
+
+#include "canInterface.h"
+
+// Leaf AZE0 readout messages
+inline constexpr CANMessage<8> aze0_dashboard_soc_readout = {0x1DB}; // AZE0 dashboard SOC
+
+// AZE0 SOC field: byte 4, bits 0-6 (7 bits)
+inline constexpr CANField aze0_soc_field = { 33, 7 };
+inline constexpr FieldScaling aze0_soc_scaling = {false, 1.0f, 0.0f};
+inline constexpr uint8_t aze0_dashboard_soc_sentinel = 0x7F; // 127
+
+inline constexpr FieldScaling aze0_cabin_temp_scaling = {false, 5.0f/9.0f, -32.0f * (5.0f/9.0f)};
+inline constexpr uint8_t aze0_cabin_temp_sentinel = 20; // 0x14
+
+#endif // CAN_LEAF_AZE0_H

--- a/simppeliTCU/simppeliTCU.ino
+++ b/simppeliTCU/simppeliTCU.ino
@@ -4,7 +4,7 @@
 #include <NetBIOS.h>
 #include "configuration.h"
 #include "cliParser.h"
-#include "canLeafZE1.h"
+#include "canLeaf.h"
 #include "ui.h"
 #include "mqttInterface.h"
 
@@ -106,7 +106,7 @@ void handleLockStatus(bool locked) {
   mqttUpdateLock(locked);
 }
 
-void handleRawSOC(float soc) {
+void handleDashboardSOC(float soc) {
   currentSOC = soc;
   mqttUpdateSOC(soc);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,10 +26,10 @@ target_include_directories(test_stubs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(can_leaf_ze1_parsing_tests
     test_canLeafZE1_parsing.cpp
-    ../simppeliTCU/canLeafZE1.cpp
+    ../simppeliTCU/canLeaf.cpp
     ../simppeliTCU/vehicleTypes.h
     ../simppeliTCU/canInterface.h
-    ../simppeliTCU/canLeafZE1.h
+    ../simppeliTCU/canLeaf.h
 )
 
 target_include_directories(can_leaf_ze1_parsing_tests PRIVATE 

--- a/test/test_canInterface_stubs.cpp
+++ b/test/test_canInterface_stubs.cpp
@@ -22,7 +22,7 @@ bool lastHeating_value = false;
 bool lastCooling_value = false;
 VentilationMode lastVentilationMode_value = VentilationMode::UNKNOWN;
 
-void handleRawSOC(float soc) {
+void handleDashboardSOC(float soc) {
     lastSOC_value = soc;
 }
 

--- a/test/test_canLeafZE1_parsing.cpp
+++ b/test/test_canLeafZE1_parsing.cpp
@@ -47,7 +47,7 @@ TEST(CanLeafZE1Parsing, ZE1_Parsing) {
     resetVehicleDetection();
     resetMocks();
     
-    // ZE1 SOC
+    // ZE1 SOC (confirms is_ze1 = true)
     uint8_t ze1SocData[8] = {0};
     ze1SocData[7] = 27; // 27 * 0.5 = 13.5%
     handleReceivedMessage(0x59E, ze1SocData, sizeof(ze1SocData));
@@ -57,6 +57,28 @@ TEST(CanLeafZE1Parsing, ZE1_Parsing) {
     ze1SocData[7] = 16; // 16 * 0.5 = 8.0%
     handleReceivedMessage(0x59E, ze1SocData, sizeof(ze1SocData));
     EXPECT_NEAR(lastSOC_value, 8.0f, 0.01f);
+    
+    // ZE1 Temp: raw * 0.5 - 40
+    resetMocks();
+    uint8_t ze1TempData1[] = {0x78}; // 120 * 0.5 - 40 = 20.0f
+    handleReceivedMessage(0x54F, ze1TempData1, sizeof(ze1TempData1));
+    EXPECT_NEAR(lastTemp_value, 20.0f, 0.01f);
+    
+    // ZE1 Temp Sentinel
+    resetMocks();
+    uint8_t ze1TempSentinel[] = {0x50}; // Sentinel (was previously 0.0f)
+    handleReceivedMessage(0x54F, ze1TempSentinel, sizeof(ze1TempSentinel));
+    EXPECT_EQ(lastTemp_value, -100.0f); // Unchanged
+    
+    resetMocks();
+    uint8_t ze1TempData3[] = {0x3C}; // 60 * 0.5 - 40 = -10.0f
+    handleReceivedMessage(0x54F, ze1TempData3, sizeof(ze1TempData3));
+    EXPECT_NEAR(lastTemp_value, -10.0f, 0.01f);
+    
+    resetMocks();
+    uint8_t ze1TempData4[] = {0xA0}; // 160 * 0.5 - 40 = 40.0f
+    handleReceivedMessage(0x54F, ze1TempData4, sizeof(ze1TempData4));
+    EXPECT_NEAR(lastTemp_value, 40.0f, 0.01f);
 }
 
 // Test AZE0 parsing (this will set is_ze1 to false)
@@ -66,7 +88,7 @@ TEST(CanLeafZE1Parsing, AZE0_Parsing) {
     
     // AZE0 SOC
     uint8_t aze0SocData[8] = {0};
-    aze0SocData[4] = 13; // 13%
+    aze0SocData[4] = 13; // 13% -> Triggers is_ze1 = false
     handleReceivedMessage(0x1DB, aze0SocData, sizeof(aze0SocData));
     EXPECT_NEAR(lastSOC_value, 13.0f, 0.01f);
 
@@ -74,30 +96,18 @@ TEST(CanLeafZE1Parsing, AZE0_Parsing) {
     aze0SocData[4] = 85; // 85%
     handleReceivedMessage(0x1DB, aze0SocData, sizeof(aze0SocData));
     EXPECT_NEAR(lastSOC_value, 85.0f, 0.01f);
-}
 
-// Test cabin temperature parsing
-TEST(CanLeafZE1Parsing, CabinTemp_Parsing) {
+    // AZE0 Temp: (raw - 32) * 5/9
     resetMocks();
-    
-    uint8_t tempData1[] = {0x78};
-    handleReceivedMessage(0x54F, tempData1, sizeof(tempData1));
+    uint8_t aze0TempData[] = {68}; // (68 - 32) * 5/9 = 20.0f
+    handleReceivedMessage(0x54F, aze0TempData, sizeof(aze0TempData));
     EXPECT_NEAR(lastTemp_value, 20.0f, 0.01f);
-    
+
+    // AZE0 Temp Sentinel
     resetMocks();
-    uint8_t tempData2[] = {0x50};
-    handleReceivedMessage(0x54F, tempData2, sizeof(tempData2));
-    EXPECT_NEAR(lastTemp_value, 0.0f, 0.01f);
-    
-    resetMocks();
-    uint8_t tempData3[] = {0x3C};
-    handleReceivedMessage(0x54F, tempData3, sizeof(tempData3));
-    EXPECT_NEAR(lastTemp_value, -10.0f, 0.01f);
-    
-    resetMocks();
-    uint8_t tempData4[] = {0xA0};
-    handleReceivedMessage(0x54F, tempData4, sizeof(tempData4));
-    EXPECT_NEAR(lastTemp_value, 40.0f, 0.01f);
+    uint8_t aze0TempSentinel[] = {20}; // Sentinel
+    handleReceivedMessage(0x54F, aze0TempSentinel, sizeof(aze0TempSentinel));
+    EXPECT_EQ(lastTemp_value, -100.0f); // Unchanged
 }
 
 // Test car awake parsing

--- a/test/test_canLeafZE1_parsing.cpp
+++ b/test/test_canLeafZE1_parsing.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "../simppeliTCU/canLeafZE1.h"
+#include "../simppeliTCU/canLeaf.h"
 #include "../simppeliTCU/vehicleTypes.h"
 
 // Mock callback functions to capture parsed values - these are defined in test_canInterface_stubs.cpp
@@ -42,23 +42,38 @@ namespace {
     }
 }
 
-// Test SOC parsing
-TEST(CanLeafZE1Parsing, SOC_Parsing) {
+// Test ZE1 parsing first (since is_ze1 defaults to true)
+TEST(CanLeafZE1Parsing, ZE1_Parsing) {
+    resetVehicleDetection();
     resetMocks();
     
-    uint8_t socData[] = {0x21, 0x98};
-    handleReceivedMessage(0x55B, socData, sizeof(socData));
-    EXPECT_NEAR(lastSOC_value, 13.4f, 0.01f);
+    // ZE1 SOC
+    uint8_t ze1SocData[8] = {0};
+    ze1SocData[7] = 27; // 27 * 0.5 = 13.5%
+    handleReceivedMessage(0x59E, ze1SocData, sizeof(ze1SocData));
+    EXPECT_NEAR(lastSOC_value, 13.5f, 0.01f);
     
     resetMocks();
-    uint8_t socData2[] = {0x14, 0x00};
-    handleReceivedMessage(0x55B, socData2, sizeof(socData2));
+    ze1SocData[7] = 16; // 16 * 0.5 = 8.0%
+    handleReceivedMessage(0x59E, ze1SocData, sizeof(ze1SocData));
     EXPECT_NEAR(lastSOC_value, 8.0f, 0.01f);
-    
+}
+
+// Test AZE0 parsing (this will set is_ze1 to false)
+TEST(CanLeafZE1Parsing, AZE0_Parsing) {
+    resetVehicleDetection();
     resetMocks();
-    uint8_t socData3[] = {0x27, 0x00};
-    handleReceivedMessage(0x55B, socData3, sizeof(socData3));
-    EXPECT_NEAR(lastSOC_value, 15.6f, 0.01f);
+    
+    // AZE0 SOC
+    uint8_t aze0SocData[8] = {0};
+    aze0SocData[4] = 13; // 13%
+    handleReceivedMessage(0x1DB, aze0SocData, sizeof(aze0SocData));
+    EXPECT_NEAR(lastSOC_value, 13.0f, 0.01f);
+
+    resetMocks();
+    aze0SocData[4] = 85; // 85%
+    handleReceivedMessage(0x1DB, aze0SocData, sizeof(aze0SocData));
+    EXPECT_NEAR(lastSOC_value, 85.0f, 0.01f);
 }
 
 // Test cabin temperature parsing
@@ -87,6 +102,7 @@ TEST(CanLeafZE1Parsing, CabinTemp_Parsing) {
 
 // Test car awake parsing
 TEST(CanLeafZE1Parsing, CarAwake_Parsing) {
+    resetVehicleDetection();
     resetMocks();
     EXPECT_FALSE(carIsAwake);
     


### PR DESCRIPTION
Adjust state of charge value to use the dasboard value instead of raw value. Also fix the cabin temperature scaling for older AZE0 models.