### PR TITLE
Add TCU emulation heartbeat to prevent DTCs (P31C2, U1000)

### DIFF
--- a/simppeliTCU/canInterface.cpp
+++ b/simppeliTCU/canInterface.cpp
@@ -23,8 +23,13 @@ void print_can_message(twai_message_t &message) {
       Serial.println();
 }
 
+unsigned long last56EMessageSentMillis = 0;
+
 // Helper function to send CAN message
 void sendCAN(uint32_t id,const uint8_t* data, uint8_t len) {
+  if (id == 0x56E) {
+      last56EMessageSentMillis = millis();
+  }
   twai_message_t message;
   message.identifier = id;
   message.extd = 0;
@@ -61,9 +66,14 @@ void setupCAN() {
   }
 }
 
+unsigned long lastCanMessageMillis = 0;
+
 void readAndHandleCANMessage() {
   twai_message_t message;
   if (twai_receive(&message, 0) == ESP_OK) { // 0 = do not wait, read only if data is available
+    if (message.identifier != 0x56E) {
+        lastCanMessageMillis = millis();
+    }
     handleReceivedMessage(message.identifier, message.data, message.data_length_code);
     Serial.print("< ");
     print_can_message(message);

--- a/simppeliTCU/canInterface.h
+++ b/simppeliTCU/canInterface.h
@@ -71,6 +71,9 @@ void handleReceivedMessage(uint32_t identifier, uint8_t* data, uint8_t len);
 void setupCAN();
 void readAndHandleCANMessage();
 
+extern unsigned long lastCanMessageMillis;
+extern unsigned long last56EMessageSentMillis;
+
 void resetCanLogTimestamps();
 
 #endif

--- a/simppeliTCU/canLeafZE1.cpp
+++ b/simppeliTCU/canLeafZE1.cpp
@@ -319,32 +319,18 @@ CanSeqResult manageCANSequence(unsigned long currentTimeMs) {
 }
 
 void manageTCUDTCPrevention(unsigned long currentTimeMs) {
-    static bool wasCanActive = false;
-    static unsigned long offStartTime = 0;
-
-    // Consider CAN bus active if we received a message (other than our own 0x56E) in the last 2 seconds
-    bool canActive = (currentTimeMs - lastCanMessageMillis < 2000); 
+    // Consider CAN bus active if we actually received a message (other than our own 0x56E) in the last 2 seconds
+    bool canActive = (lastCanMessageMillis != 0) && (currentTimeMs - lastCanMessageMillis < 2000);
 
     if (canActive) {
-        if (!wasCanActive) {
-            wasCanActive = true;
-        }
-        // If no 0x56E message has been sent in the last 120ms, act as a watchdog and send heartbeat
+        // If no 0x56E message has been sent in the last 120ms, act as a watchdog and send heartbeat.
+        // We use idle_data (0x86) instead of hvac_init (0x46) so we don't accidentally keep the climate
+        // control electronics awake or disrupt sequences.
         if (currentTimeMs - last56EMessageSentMillis >= 120) {
-            sendCAN(hvac_init);
-        }
-    } else {
-        if (wasCanActive) {
-            offStartTime = currentTimeMs;
-            wasCanActive = false;
-        }
-        
-        // "When vehicle is turning OFF, last few seconds of CAN bus activity"
-        // If the CAN bus just went inactive, send 0x86 a few times to emulate turning OFF
-        if (offStartTime != 0 && (currentTimeMs - offStartTime < 2000)) {
-            if (currentTimeMs - last56EMessageSentMillis >= 120) {
-                sendCAN(idle_data);
-            }
+            sendCAN(idle_data);
         }
     }
+    // We intentionally do NOT send anything when canActive is false.
+    // Sending messages after the bus goes quiet will wake the car's ECUs back up,
+    // creating an infinite loop that drains the 12V battery!
 }

--- a/simppeliTCU/canLeafZE1.cpp
+++ b/simppeliTCU/canLeafZE1.cpp
@@ -317,3 +317,34 @@ CanSeqResult manageCANSequence(unsigned long currentTimeMs) {
     }
     return CanSeqResult::PROCESSING;
 }
+
+void manageTCUDTCPrevention(unsigned long currentTimeMs) {
+    static bool wasCanActive = false;
+    static unsigned long offStartTime = 0;
+
+    // Consider CAN bus active if we received a message (other than our own 0x56E) in the last 2 seconds
+    bool canActive = (currentTimeMs - lastCanMessageMillis < 2000); 
+
+    if (canActive) {
+        if (!wasCanActive) {
+            wasCanActive = true;
+        }
+        // If no 0x56E message has been sent in the last 120ms, act as a watchdog and send heartbeat
+        if (currentTimeMs - last56EMessageSentMillis >= 120) {
+            sendCAN(hvac_init);
+        }
+    } else {
+        if (wasCanActive) {
+            offStartTime = currentTimeMs;
+            wasCanActive = false;
+        }
+        
+        // "When vehicle is turning OFF, last few seconds of CAN bus activity"
+        // If the CAN bus just went inactive, send 0x86 a few times to emulate turning OFF
+        if (offStartTime != 0 && (currentTimeMs - offStartTime < 2000)) {
+            if (currentTimeMs - last56EMessageSentMillis >= 120) {
+                sendCAN(idle_data);
+            }
+        }
+    }
+}

--- a/simppeliTCU/canLeafZE1.h
+++ b/simppeliTCU/canLeafZE1.h
@@ -89,5 +89,6 @@ void setHVACTargetTemperature(float setpoint);
 
 void startSequence(CanSequence seq, unsigned long currentTimeMs);
 CanSeqResult manageCANSequence(unsigned long currentTimeMs);
+void manageTCUDTCPrevention(unsigned long currentTimeMs);
 
 #endif

--- a/simppeliTCU/simppeliTCU.ino
+++ b/simppeliTCU/simppeliTCU.ino
@@ -384,6 +384,7 @@ void loop() {
   manageMQTT();
   readAndHandleCANMessage();
   CanSeqResult seqRes = manageCANSequence(millis());
+  manageTCUDTCPrevention(millis());
   if (seqRes == CanSeqResult::WAKE_SUCCESS) {
       Serial.println("### Car is awake! ###");
   } else if (seqRes == CanSeqResult::WAKE_TIMEOUT) {

--- a/test/test_canInterface_stubs.cpp
+++ b/test/test_canInterface_stubs.cpp
@@ -4,6 +4,8 @@
 #include "../simppeliTCU/vehicleTypes.h"
 
 bool carIsAwake = false;
+unsigned long lastCanMessageMillis = 0;
+unsigned long last56EMessageSentMillis = 0;
 
 float lastSOC_value = -1.0f;
 float lastTemp_value = -100.0f;


### PR DESCRIPTION
When disconnecting the original TCU, the vehicle expects periodic heartbeat messages on CAN ID 0x56E, otherwise it triggers fault codes such as P31C2 (TCU EVC-273) and U1000.

This commit implements the required logic to emulate the TCU:
